### PR TITLE
fix: remove empty functions object from Vercel configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,9 @@
 {
   "buildCommand": "npm run build",
-  "devCommand": "npm run dev",
+  "devCommand": "npm run dev", 
   "installCommand": "npm install",
   "outputDirectory": "dist",
   "framework": "vite",
-  "functions": {},
   "headers": [
     {
       "source": "/assets/(.*)",


### PR DESCRIPTION
This pull request makes a minor change to the `vercel.json` configuration file by removing the empty `functions` object, which helps clean up the configuration.