### PR TITLE
fix: Remove modal prop from DropdownMenu in DashboardDetails, Lineage…

### DIFF
--- a/src/components/DashboardDetails.tsx
+++ b/src/components/DashboardDetails.tsx
@@ -154,7 +154,7 @@ const DashboardDetails: React.FC<DashboardDetailsProps> = ({
                   </p>
                 </div>
                 {onConnectTable && (
-                  <DropdownMenu modal={false}>
+                  <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <Button variant="outline" size="sm" className="gap-1">
                         <Plus className="h-3 w-3" />

--- a/src/components/LineageGraph.tsx
+++ b/src/components/LineageGraph.tsx
@@ -520,17 +520,25 @@ const LineageGraph: React.FC<LineageGraphProps> = ({
   // Handle context menu click outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      // Don't close context menus if clicking on dropdown menu elements or sheet panels
+      // Don't close context menus if clicking on UI elements
       const target = event.target as Element;
       if (target && (
+        // Dropdown menu elements
         target.closest('[data-radix-dropdown-menu-content]') ||
         target.closest('[data-radix-dropdown-menu-trigger]') ||
         target.closest('[role="menuitem"]') ||
         target.closest('[role="menu"]') ||
+        // Sheet/Dialog elements
         target.closest('[data-radix-dialog-content]') ||
         target.closest('[data-radix-sheet-content]') ||
+        target.closest('[data-radix-dialog-overlay]') ||
+        target.closest('[data-radix-sheet-overlay]') ||
         target.closest('.sheet-content') ||
-        target.closest('[role="dialog"]')
+        target.closest('[role="dialog"]') ||
+        // Any UI component that might contain dropdowns
+        target.closest('.lucide') || // Icon buttons
+        target.closest('button') || // All buttons
+        target.closest('[data-state="open"]') // Any open dropdown/popover
       )) {
         return;
       }

--- a/src/components/TableDetails.tsx
+++ b/src/components/TableDetails.tsx
@@ -464,7 +464,7 @@ const TableDetails: React.FC<TableDetailsProps> = ({
                     Upstream tables ({upstreamTables.size})
                   </h3>
                   {onConnectUpstream && (
-                    <DropdownMenu modal={false}>
+                    <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <Button variant="outline" size="sm" className="gap-1">
                           <Plus className="h-3 w-3" />
@@ -543,7 +543,7 @@ const TableDetails: React.FC<TableDetailsProps> = ({
                     Downstream tables ({downstreamTables.size})
                   </h3>
                   {onConnectDownstream && (
-                    <DropdownMenu modal={false}>
+                    <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <Button variant="outline" size="sm" className="gap-1">
                           <Plus className="h-3 w-3" />


### PR DESCRIPTION
This pull request makes minor improvements to the dropdown menu and context menu handling in the UI components. The main changes are removing the `modal={false}` prop from several `DropdownMenu` components and expanding the logic for detecting UI elements when handling context menu clicks.

Dropdown menu improvements:

* Removed the `modal={false}` prop from the `DropdownMenu` components in `DashboardDetails`, `TableDetails` (upstream), and `TableDetails` (downstream) to use the default modal behavior. [[1]](diffhunk://#diff-b60e892d5fbb380416c464289306fd812e89251abd192956b103305a6624552eL157-R157) [[2]](diffhunk://#diff-e2295223f51e7f876cbd0fbbcf2018129001bcbfdd09aa8d6f2f2faba0d07283L467-R467) [[3]](diffhunk://#diff-e2295223f51e7f876cbd0fbbcf2018129001bcbfdd09aa8d6f2f2faba0d07283L546-R546)

Context menu handling:

* Expanded the click-outside detection logic in `LineageGraph` to include more UI elements (such as icon buttons, all buttons, and open dropdowns/popovers), making context menus less likely to close unintentionally when interacting with related UI components.…Graph, and TableDetails components for consistent UI behavior